### PR TITLE
Feste Zusage an Laura Steiner

### DIFF
--- a/Community-Aktivitäten/README.md
+++ b/Community-Aktivitäten/README.md
@@ -73,7 +73,7 @@ Dauer: 2 Stunden
 Ausstattung: Raum mit Beamer und WLAN.
 
 
-## Jetpack Compose Hands-On mit Kotlin (JUG Stuttgart: *Laura Steiner*, Michael Paus, Frank Gerhardt)
+## Jetpack Compose Hands-On mit Kotlin (JUG Stuttgart: *Laura Steiner*, Michael Paus, Frank Gerhardt) **FEST ZUGESAGT**
 
 Beschreibung: TBD.
 


### PR DESCRIPTION
Diesen CAs sage ich heute fest zu, da wir sie bereits im Prospekt angekündigt haben, über die anderen entscheiden wir nach Klärung der Raumsituation.