### PR TITLE
Nicht-existienden Merge-Konflikt gelöst

### DIFF
--- a/Community-Aktivitäten/README.md
+++ b/Community-Aktivitäten/README.md
@@ -154,6 +154,18 @@ Dauer: 2,5 Stunden.
 Ausstattung: WLAN, Beamer, Je nach Interesse der Teilnehmer, Gruppen-Tische, Pro Tisch ein Fernseher. Vier Gruppen max. oder 2/3er Gruppen.
 
 
+## HTMX und Java ([JUG Paderborn](https://jug-pb.gitlab.io/): [*Frederik Hahne*](https://www.linkedin.com/in/frederikhahne/))
+
+Beschreibung: Nachdem intercooler.js keine große Beachtung gefunden hat, da Frameworks wie React, Angular und Vue allgegenwärtig waren hat es HTMX inzwischen sogar auf das Techradar von Thoughworks geschafft.
+In diesem kleinen Workshop möchte ich euch HTMX etwas näher bringen und wie man es im Java Umfeld verwenden kann. Bringt euren Laptop mit und wir bauen zusammen eine kleine Anwendung mit Spring Boot, Quarkus oder Micronaut und HTMX.
+
+Teilnahmevoraussetzungen: Laptop mit Java Entwicklungsumgebung
+
+Dauer: 2 Stunden (bei Bedarf auch gerne mehr)
+
+Ausstattung: großer Screen/Beamer, Internet
+
+
 ## TEMPLATE
 
 Beschreibung: 


### PR DESCRIPTION
Github weigert sich beharrlich, [den originalen PR #40](https://github.com/ijug-ev/JavaLand/pull/40) zu HTMX von @atomfrede zu mergen wegen eines angeblichen Konflikts. Tatsächlich ist der Konflikt aber längst gelöst. Da sich die Github-UI nicht dazu überreden lässt, den Merge nun durchzuführen, und da augenscheinlich (entgegen Github-Doku) nicht einmal meine Admin-Rechte im Zielrepo reichen, um *direkt* dorthin zu pushen, habe ich kurzerhand einen eigenen PR mit dem gleichen Inhalt gestellt. 🤕 